### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Where as this code makes only one:
 The client uses [Typhoeus](https://github.com/dbalatero/typhoeus) which
 respects the `http_proxy` environment variable
 
-### "Your account has been comprimised"
+### "Your account has been compromised"
 
 You might get your account locked if you repeatedly login, especially from
 multiple IP's. To be on the safe side you should reuse the `token` assigned to


### PR DESCRIPTION
@bbcsnippets, I've corrected a typographical error in the documentation of the [redux-client-ruby](https://github.com/bbcsnippets/redux-client-ruby) project. Specifically, I've changed comprimise to compromise. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.